### PR TITLE
WIP: feat: Decouple logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,9 @@ gem "thruster", require: false
 # Provide Concurrency abstractions like Promises
 gem "concurrent-ruby", require: "concurrent"
 
+# Local testing of turbo_frame_async gem
+gem "turbo_frame_async", path: "./turbo_frame_async"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+PATH
+  remote: turbo_frame_async
+  specs:
+    turbo_frame_async (0.1.0)
+      concurrent-ruby
+      concurrent-ruby-edge
+      rails (>= 6.1.0)
+      turbo-rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -97,6 +106,8 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     concurrent-ruby (1.3.5)
+    concurrent-ruby-edge (0.7.2)
+      concurrent-ruby (~> 1.3)
     connection_pool (2.5.0)
     crass (1.0.6)
     date (3.4.1)
@@ -414,6 +425,7 @@ DEPENDENCIES
   stimulus-rails
   thruster
   turbo-rails
+  turbo_frame_async!
   tzinfo-data
   web-console
 

--- a/app/controllers/async_with_block_controller.rb
+++ b/app/controllers/async_with_block_controller.rb
@@ -1,0 +1,34 @@
+class AsyncWithBlockController < ApplicationController
+  include TurboFrameAsync::Helper
+
+  def index
+    sleeptime1 = 1
+
+    data1 = async_execute {
+      sleep sleeptime1
+      {data1: "world1", sleeptime: sleeptime1}
+     }
+
+    sleeptime2 = 1
+    data2 = async_execute {
+      sleep sleeptime2
+      {data3: "world2", sleeptime: sleeptime2}
+    }
+
+    sleeptime3 = 3
+    data3 = async_execute do
+      sleep sleeptime3
+      # TODO: Need to figure oute why error is not tracked
+      raise StandardError.new("Custom error message")
+      {data3: "world3", sleeptime: sleeptime3}
+    end
+
+    sleeptime4 = 5
+    data4 = Concurrent::Promises.future {
+      sleep sleeptime4
+      {data4: "world4", sleeptime: sleeptime4}
+    }
+
+    render :index, locals: {id: params[:id], data1:, data2:, data3:, data4:}
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,17 +1,2 @@
 module ApplicationHelper
-  def turbo_frame_tag_async(dom_id, *data, loading: "Loading...", &)
-    async_tag_id = "async_tag_" + SecureRandom.hex(5)
-
-    Concurrent::Promises.zip(*data).then do |*values|
-      html_block = capture(*values, &)
-      Turbo::StreamsChannel.broadcast_replace_to(async_tag_id, target: dom_id, html: html_block)
-    end
-
-    output = turbo_stream_from async_tag_id
-    frame = turbo_frame_tag dom_id do
-      loading
-    end
-    output << frame
-    output.html_safe
-  end
 end

--- a/app/views/async_with_block/index.html.erb
+++ b/app/views/async_with_block/index.html.erb
@@ -1,0 +1,54 @@
+<div class="holy-grail-flexbox">
+    <header class="header">Async With Blok Method: turbo_frame_tag_async "tag", data1, data2 do |async_tag|</header>
+
+    <section class="left-sidebar">
+      <p> Default `loading`, `failure` msgs </p>
+
+      <%= turbo_frame_tag_async "widget2", data1, data3 %>
+    </section>
+
+    <main class="main-content">
+      <p> Custom `loading`, `success` msgs </p>
+
+      <%= turbo_frame_tag_async "widget1", data1, data2 do |async_tag| %>
+        <% async_tag.on_loading do %>
+          <div class="loading">
+            <span>Loading Widget...</span>
+          </div>
+        <% end %>
+
+        <% async_tag.on_success do |d1, d2| %>
+          <div class="success">
+            Data 1: <%= d1 %>
+            Data 2: <%= d2 %>
+          </div>
+        <% end %>
+
+        <% async_tag.on_failure do |error| %>
+          <div class="error">
+            Something went wrong: <%= error.to_s %>
+          </div>
+        <% end %>
+      <% end %>
+    </main>
+
+    <aside class="right-sidebar">
+      <p> Custom `loading`, `failure` msgs </p>
+
+      <%= turbo_frame_tag_async "widget3", data2, data3 do |async_tag| %>
+        <% async_tag.on_loading do %>
+          <div class="loading">
+            <span>Loading Widget with custom error...</span>
+          </div>
+        <% end %>
+
+        <% async_tag.on_failure do |error| %>
+          <div class="error">
+            Something went wrong: <%= error.class %>
+          </div>
+        <% end %>
+      <% end %>
+    </aside>
+
+    <footer class="footer"></footer>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,6 @@ Rails.application.routes.draw do
 
   get "async", to: "async#index"
   get "async/widget/:id", to: "async#widget", as: :async_widget
+
+  get "async_with_block", to: "async_with_block#index"
 end

--- a/turbo_frame_async/.gitignore
+++ b/turbo_frame_async/.gitignore
@@ -1,0 +1,8 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/

--- a/turbo_frame_async/.rubocop.yml
+++ b/turbo_frame_async/.rubocop.yml
@@ -1,0 +1,13 @@
+AllCops:
+  TargetRubyVersion: 3.0
+
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+Layout/LineLength:
+  Max: 120

--- a/turbo_frame_async/CHANGELOG.md
+++ b/turbo_frame_async/CHANGELOG.md
@@ -1,0 +1,5 @@
+## [Unreleased]
+
+## [0.1.0] - 2025-01-25
+
+- Initial release

--- a/turbo_frame_async/CODE_OF_CONDUCT.md
+++ b/turbo_frame_async/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at o.chuev@mobidev.biz. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0,
+available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.

--- a/turbo_frame_async/Gemfile
+++ b/turbo_frame_async/Gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in turbo_frame_async.gemspec
+gemspec
+
+gem "rake", "~> 13.0"
+
+gem "rubocop", "~> 1.21"

--- a/turbo_frame_async/LICENSE.txt
+++ b/turbo_frame_async/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2025 OlegChuev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/turbo_frame_async/LICENSE.txt
+++ b/turbo_frame_async/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2025 OlegChuev
+Copyright (c) 2025 Oleg Chuev, Yevhen Kuzminov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/turbo_frame_async/README.md
+++ b/turbo_frame_async/README.md
@@ -1,0 +1,129 @@
+# TurboFrameAsync
+
+TurboFrameAsync is a Ruby gem that enhances Turbo Frames with asynchronous capabilities. It allows you to handle multiple promises in your Rails views with elegant loading, success, and failure states.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'turbo_frame_async'
+```
+And then execute:
+
+```bash
+bundle install
+```
+
+## Usage
+
+### Basic Example
+
+In your controller:
+
+```ruby
+class DashboardController < ApplicationController
+  include TurboFrameAsync::Helper
+
+  def index
+    @user_data = async_execute {
+      User.find(params[:id])
+    }
+
+    @posts_data = async_execute {
+      Post.where(user_id: params[:id])
+    }
+  end
+end
+```
+
+In your view:
+
+```erb
+<%= turbo_frame_tag_async "dashboard", @user_data, @posts_data do |frame| %>
+  <% frame.on_loading do %>
+    <div class="loading">Loading dashboard data...</div>
+  <% end %>
+
+  <% frame.on_success do |user, posts| %>
+    <div class="dashboard">
+      <h1><%= user.name %>'s Dashboard</h1>
+      <%= render partial: "posts", locals: { posts: posts } %>
+    </div>
+  <% end %>
+
+  <% frame.on_failure do |error| %>
+    <div class="error">
+      Error loading dashboard: <%= error.message %>
+    </div>
+  <% end %>
+<% end %>
+```
+
+## Configuration
+
+You can configure the executor used for async operations:
+
+```ruby
+# config/initializers/turbo_frame_async.rb
+
+TurboFrameAsync.configure do |config|
+  config.executor = Concurrent::ThreadPoolExecutor.new(
+    min_threads: 1,
+    max_threads: 10,
+    max_queue: 50,
+    fallback_policy: :caller_runs
+  )
+end
+```
+
+Default configuration is provided out of the box, so this step is optional.
+
+### Helper Methods
+
+`async_execute`
+Creates a promise that executes the given block asynchronously:
+
+```ruby
+data = async_execute {
+  # Long-running operation
+  User.complex_query
+}
+```
+
+`turbo_frame_tag_async`
+Creates an async Turbo Frame that handles promise states:
+
+```erb
+<%= turbo_frame_tag_async "my-frame", promise1, promise2 do |frame| %>
+  <% frame.on_loading do %>
+    <!-- Loading state content -->
+  <% end %>
+
+  <% frame.on_success do |result1, result2| %>
+    <!-- Success state content -->
+  <% end %>
+
+  <% frame.on_failure do |error| %>
+    <!-- Error state content -->
+  <% end %>
+<% end %>
+```
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/turbo_frame_async. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/[USERNAME]/turbo_frame_async/blob/master/CODE_OF_CONDUCT.md).
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+
+## Code of Conduct
+
+Everyone interacting in the TurboFrameAsync project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/turbo_frame_async/blob/master/CODE_OF_CONDUCT.md).

--- a/turbo_frame_async/Rakefile
+++ b/turbo_frame_async/Rakefile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "bundler/gem_tasks"
+require "rubocop/rake_task"
+
+RuboCop::RakeTask.new
+
+task default: :rubocop

--- a/turbo_frame_async/bin/console
+++ b/turbo_frame_async/bin/console
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "turbo_frame_async"
+
+require "irb"
+IRB.start(__FILE__)

--- a/turbo_frame_async/bin/setup
+++ b/turbo_frame_async/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/turbo_frame_async/lib/generators/turbo_frame_async/templates/initializer.rb
+++ b/turbo_frame_async/lib/generators/turbo_frame_async/templates/initializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+TurboFrameAsync.configure do |config|
+  # Configure custom executor if needed
+  # config.executor = Concurrent::WrappingExecutor.new(
+  #   min_threads: 0,
+  #   max_threads: 10,
+  #   max_queue: 100,
+  #   fallback_policy: :caller_runs
+  # )
+end

--- a/turbo_frame_async/lib/turbo_frame_async.rb
+++ b/turbo_frame_async/lib/turbo_frame_async.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "concurrent"
+require "concurrent-edge"
+require "turbo-rails"
+require "turbo_frame_async/version"
+require "turbo_frame_async/configuration"
+require "turbo_frame_async/promise_handler"
+require "turbo_frame_async/helper"
+require "turbo_frame_async/railtie" if defined?(Rails)
+
+module TurboFrameAsync
+  class Error < StandardError; end
+end

--- a/turbo_frame_async/lib/turbo_frame_async.rb
+++ b/turbo_frame_async/lib/turbo_frame_async.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "concurrent"
-require "concurrent-edge"
 require "turbo-rails"
 require "turbo_frame_async/version"
 require "turbo_frame_async/configuration"

--- a/turbo_frame_async/lib/turbo_frame_async/configuration.rb
+++ b/turbo_frame_async/lib/turbo_frame_async/configuration.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module TurboFrameAsync
+  # Configuration class for TurboFrameAsync gem that handles async operations settings.
+  # Provides configuration options for the executor that processes async promises.
+  #
+  # @since 0.1.0
+  # @example Configure custom executor
+  #   TurboFrameAsync.configure do |config|
+  #     config.executor = Concurrent::ThreadPoolExecutor.new(max_threads: 10)
+  #   end
+  # @example Use default configuration
+  #   # No configuration needed, uses default executor
+  #   TurboFrameAsync.configuration.executor
+  class Configuration
+    # Default minimum number of threads in the executor pool
+    # @api private
+    DEFAULT_MIN_THREADS = 0
+
+    # Default maximum number of threads in the executor pool
+    # @api private
+    DEFAULT_MAX_THREADS = 5
+
+    # Default maximum size of the task queue
+    # @api private
+    DEFAULT_MAX_QUEUE = 100
+
+    # Default policy for handling tasks when queue is full
+    # @api private
+    DEFAULT_FALLBACK_POLICY = :caller_runs
+
+    # The executor instance used for handling concurrent promises
+    # @return [Concurrent::ThreadPoolExecutor] The configured executor instance
+    # @example Set custom executor
+    #   config.executor = Concurrent::ThreadPoolExecutor.new(max_threads: 10)
+    attr_accessor :executor
+
+    # Initializes a new Configuration instance with default settings.
+    # Creates a default executor if none is provided.
+    #
+    # @return [Configuration] A new configuration instance
+    # @see #build_default_executor
+    def initialize
+      @executor = build_default_executor
+    end
+
+    private
+
+    # Builds the default executor with predefined settings.
+    # Uses ThreadPoolExecutor for better thread management and fallback handling.
+    #
+    # @return [Concurrent::ThreadPoolExecutor] A new executor instance with default settings
+    # @api private
+    def build_default_executor
+      Concurrent::ThreadPoolExecutor.new(
+        min_threads: DEFAULT_MIN_THREADS,
+        max_threads: DEFAULT_MAX_THREADS,
+        max_queue: DEFAULT_MAX_QUEUE,
+        fallback_policy: DEFAULT_FALLBACK_POLICY
+      )
+    end
+  end
+
+  class << self
+    # Returns the current configuration instance.
+    # Creates a new configuration with default settings if none exists.
+    #
+    # @return [Configuration] The current configuration instance
+    # @see Configuration#initialize
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    # Configures the gem using a block.
+    # Yields the current configuration instance for modification.
+    #
+    # @yield [config] Configuration instance
+    # @yieldparam config [Configuration] The configuration instance to modify
+    # @return [void]
+    # @example Configure custom executor
+    #   TurboFrameAsync.configure do |config|
+    #     config.executor = Concurrent::ThreadPoolExecutor.new(
+    #       min_threads: 1,
+    #       max_threads: 10,
+    #       max_queue: 50,
+    #       fallback_policy: :caller_runs
+    #     )
+    #   end
+    def configure
+      yield(configuration)
+    end
+  end
+end

--- a/turbo_frame_async/lib/turbo_frame_async/helper.rb
+++ b/turbo_frame_async/lib/turbo_frame_async/helper.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module TurboFrameAsync
+  # View helper module that provides methods for creating asynchronous Turbo Frames
+  # with support for loading, success, and failure states.
+  #
+  # @since 0.1.0
+  module Helper
+    # Size of the random hex string used for generating unique async tag IDs
+    # @api private
+    HEX_SIZE = 12
+
+    # Creates an asynchronous Turbo Frame that handles multiple promises and their states.
+    # This helper method sets up a Turbo Frame that can show different content based on
+    # the promise states (loading, success, failure) and handles the async updates through
+    # Turbo Streams.
+    #
+    # @param dom_id [String] The DOM ID for the Turbo Frame
+    # @param promises [Array<Concurrent::Promise>] One or more promises to handle
+    # @yield [handler] Block for defining state contents using the PromiseHandler
+    # @yieldparam handler [PromiseHandler] The handler instance for setting up state blocks
+    # @return [ActiveSupport::SafeBuffer] The HTML output containing the Turbo Frame
+    #
+    # @example Basic usage with all states
+    #   <%= turbo_frame_tag_async "user-profile", user_data_promise do |frame| %>
+    #     <% frame.on_loading do %>
+    #       <div class="spinner">Loading user data...</div>
+    #     <% end %>
+    #
+    #     <% frame.on_success do |user| %>
+    #       <div class="profile">
+    #         <h2><%= user.name %></h2>
+    #         <p><%= user.bio %></p>
+    #       </div>
+    #     <% end %>
+    #
+    #     <% frame.on_failure do |error| %>
+    #       <div class="error">
+    #         Failed to load user: <%= error.message %>
+    #       </div>
+    #     <% end %>
+    #   <% end %>
+    #
+    # @example Multiple promises
+    #   <%= turbo_frame_tag_async "dashboard", users_promise, posts_promise do |frame| %>
+    #     <% frame.on_success do |users, posts| %>
+    #       <div class="dashboard">
+    #         <div class="users"><%= render users %></div>
+    #         <div class="posts"><%= render posts %></div>
+    #       </div>
+    #     <% end %>
+    #   <% end %>
+    def turbo_frame_tag_async(dom_id, *promises)
+      async_tag_id = "async_tag_" + SecureRandom.hex(HEX_SIZE)
+      handler = PromiseHandler.new(dom_id, async_tag_id, self)
+
+      yield(handler) if block_given?
+
+      output = ActiveSupport::SafeBuffer.new
+      output << turbo_stream_from(async_tag_id)
+      output << turbo_frame_tag(dom_id) { handler.render_loading }
+
+      handler.handle_promises(promises)
+
+      output
+    end
+
+    # Creates a promise that executes the given block on the configured executor
+    #
+    # @yield Block to be executed asynchronously
+    # @return [Concurrent::Promise] A promise that will resolve with the block's result
+    # @example
+    #   # In your controller:
+    #   def index
+    #     @user_promise = async_execute { User.find(params[:id]) }
+    #     @posts_promise = async_execute { Post.where(user_id: params[:id]) }
+    #   end
+    #
+    #   # In your view:
+    #   <%= turbo_frame_tag_async "user-data", @user_promise, @posts_promise do |frame| %>
+    #     <% frame.on_success do |user, posts| %>
+    #       <%= render "user_dashboard", user: user, posts: posts %>
+    #     <% end %>
+    #   <% end %>
+    def async_execute(&block)
+      Concurrent::Promises.future_on(TurboFrameAsync.configuration.executor, &block)
+    end
+  end
+end

--- a/turbo_frame_async/lib/turbo_frame_async/promise_handler.rb
+++ b/turbo_frame_async/lib/turbo_frame_async/promise_handler.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+module TurboFrameAsync
+  # Handles the processing and broadcasting of promise results for asynchronous Turbo Frames.
+  # This class manages the lifecycle of promises, their states, and broadcasts the appropriate
+  # content through Turbo Streams based on promise resolution or rejection.
+  #
+  # @since 0.1.0
+  # @api private
+  class PromiseHandler
+    include ActionView::Helpers::CaptureHelper
+    include ActionView::Helpers::TagHelper
+    include ActionView::Context
+
+    # Initializes a new PromiseHandler instance
+    #
+    # @param dom_id [String] The DOM ID of the target Turbo Frame element
+    # @param async_tag_id [String] The unique identifier for the async tag
+    # @param view_context [ActionView::Base] The view context for rendering templates
+    # @api private
+    def initialize(dom_id, async_tag_id, view_context = nil)
+      @dom_id = dom_id
+      @async_tag_id = async_tag_id
+      @view_context = view_context
+      @blocks = default_blocks
+    end
+
+    # Sets the loading state content block
+    #
+    # @yield Block that renders loading state content
+    # @return [void]
+    # @example
+    #   handler.on_loading do
+    #     content_tag(:div, "Loading data...", class: "spinner")
+    #   end
+    def on_loading(&block)
+      @blocks[:loading] = block if block_given?
+    end
+
+    # Sets the success state content block
+    #
+    # @yield [*values] Block that renders success state content
+    # @yieldparam values [Array] Values from the resolved promises
+    # @return [void]
+    # @example
+    #   handler.on_success do |user, posts|
+    #     render partial: "user_dashboard", locals: { user: user, posts: posts }
+    #   end
+    def on_success(&block)
+      @blocks[:success] = block if block_given?
+    end
+
+    # Sets the failure state content block
+    #
+    # @yield [error] Block that renders failure state content
+    # @yieldparam error [StandardError] The error from the rejected promise
+    # @return [void]
+    # @example
+    #   handler.on_failure do |error|
+    #     content_tag(:div, error.message, class: "alert alert-error")
+    #   end
+    def on_failure(&block)
+      @blocks[:failure] = block if block_given?
+    end
+
+    # Processes the given promises and handles their resolution/rejection
+    #
+    # @param promises [Array<Concurrent::Promise>] The promises to handle
+    # @return [void]
+    # @api private
+    def handle_promises(promises)
+      return if promises.empty?
+
+      # Wait promises
+      Concurrent::Promises
+        .zip(*promises)
+        .then_on(TurboFrameAsync.configuration.executor) { |*values| broadcast_success(values) }
+        .rescue_on(TurboFrameAsync.configuration.executor) { |error| Rails.logger.error("Promise rejected with error: #{error.inspect}") && broadcast_failure(error) }
+    rescue StandardError => e
+      Rails.logger.error("PromiseHandler error: #{e.message}")
+      Rails.logger.error(e.backtrace.join("\n"))
+
+      broadcast_failure(e)
+    end
+
+    # Renders the initial loading state content
+    #
+    # @return [String] The HTML content for loading state
+    # @api private
+    def render_loading
+      render_block(@blocks[:loading])
+    end
+
+    private
+
+    # Returns the default content blocks for each state
+    #
+    # @return [Hash] Hash containing default blocks for loading, success, and failure states
+    # @api private
+    def default_blocks
+      {
+        loading: -> { content_tag(:div, "Loading...") },
+        success: ->(*) { content_tag(:div, "Content loaded!") },
+        failure: ->(*) { content_tag(:div, "Error loading content") }
+      }
+    end
+
+    # Broadcasts success content to the Turbo Stream
+    #
+    # @param values [Array] The resolved promise values
+    # @return [void]
+    # @api private
+    def broadcast_success(values)
+      return unless @blocks[:success]
+
+      html_content = render_block(@blocks[:success], *values)
+      broadcast_content(html_content)
+    end
+
+    # Broadcasts failure content to the Turbo Stream
+    #
+    # @param error [StandardError] The error from rejected promise
+    # @return [void]
+    # @api private
+    def broadcast_failure(error)
+      return unless @blocks[:failure]
+
+      html_content = render_block(@blocks[:failure], error)
+      broadcast_content(html_content)
+    end
+
+    # Safely renders a block with the given arguments
+    #
+    # @param block [Proc] The block to render
+    # @param args [Array] Arguments to pass to the block
+    # @return [String] The rendered HTML content
+    # @api private
+    def render_block(block, *args)
+      if @view_context
+        @view_context.capture(*args, &block)
+      else
+        capture(*args, &block)
+      end.strip.html_safe
+    end
+
+    # Broadcasts content to the Turbo Stream
+    #
+    # @param html_content [String] The HTML content to broadcast
+    # @return [void]
+    # @api private
+    def broadcast_content(html_content)
+      Turbo::StreamsChannel.broadcast_replace_to(@async_tag_id, target: @dom_id, html: html_content)
+    end
+  end
+end

--- a/turbo_frame_async/lib/turbo_frame_async/promise_handler.rb
+++ b/turbo_frame_async/lib/turbo_frame_async/promise_handler.rb
@@ -75,11 +75,12 @@ module TurboFrameAsync
       Concurrent::Promises
         .zip(*promises)
         .then_on(TurboFrameAsync.configuration.executor) { |*values| broadcast_success(values) }
-        .rescue_on(TurboFrameAsync.configuration.executor) { |error| Rails.logger.error("Promise rejected with error: #{error.inspect}") && broadcast_failure(error) }
+        .rescue_on(TurboFrameAsync.configuration.executor) do |error|
+          Rails.error.report(error)
+          broadcast_failure(error)
+        end
     rescue StandardError => e
-      Rails.logger.error("PromiseHandler error: #{e.message}")
-      Rails.logger.error(e.backtrace.join("\n"))
-
+      Rails.error.report(e)
       broadcast_failure(e)
     end
 

--- a/turbo_frame_async/lib/turbo_frame_async/railtie.rb
+++ b/turbo_frame_async/lib/turbo_frame_async/railtie.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module TurboFrameAsync
+  # Rails integration for TurboFrameAsync
+  # @since 0.1.0
+  class Railtie < Rails::Railtie
+    # Includes the helper in ActionView
+    initializer "turbo_frame_async.helper" do
+      ActiveSupport.on_load(:action_view) do
+        include TurboFrameAsync::Helper
+      end
+    end
+  end
+end

--- a/turbo_frame_async/lib/turbo_frame_async/version.rb
+++ b/turbo_frame_async/lib/turbo_frame_async/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module TurboFrameAsync
+  VERSION = "0.1.0"
+end

--- a/turbo_frame_async/sig/turbo_frame_async.rbs
+++ b/turbo_frame_async/sig/turbo_frame_async.rbs
@@ -1,0 +1,4 @@
+module TurboFrameAsync
+  VERSION: String
+  # See the writing guide of rbs: https://github.com/ruby/rbs#guides
+end

--- a/turbo_frame_async/turbo_frame_async.gemspec
+++ b/turbo_frame_async/turbo_frame_async.gemspec
@@ -5,7 +5,7 @@ require_relative "lib/turbo_frame_async/version"
 Gem::Specification.new do |spec|
   spec.name = "turbo_frame_async"
   spec.version = TurboFrameAsync::VERSION
-  spec.authors = ["Your Name"]
+  spec.authors = ["Oleg Chuev", "Yevhen Kuzminov"]
   spec.email = ["your.email@example.com"]
 
   spec.summary = "Async loading capability for Turbo Frames"

--- a/turbo_frame_async/turbo_frame_async.gemspec
+++ b/turbo_frame_async/turbo_frame_async.gemspec
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative "lib/turbo_frame_async/version"
+
+Gem::Specification.new do |spec|
+  spec.name = "turbo_frame_async"
+  spec.version = TurboFrameAsync::VERSION
+  spec.authors = ["Your Name"]
+  spec.email = ["your.email@example.com"]
+
+  spec.summary = "Async loading capability for Turbo Frames"
+  spec.description = "Provides async loading capability for Turbo Frames with loading/success/failure states"
+  spec.homepage = "https://github.com/yourusername/turbo_frame_async"
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 2.7.0"
+
+  # Prevent pushing this gem to RubyGems.org during development
+  spec.metadata["allowed_push_host"] = "none"
+
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = spec.homepage
+  # Remove changelog_uri for now since we don't have one yet
+  # spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
+
+  spec.files = Dir[
+    "lib/**/*",
+    "MIT-LICENSE",
+    "Rakefile",
+    "README.md"
+  ]
+
+  spec.add_dependency "concurrent-ruby"
+  spec.add_dependency "concurrent-ruby-edge"
+  spec.add_dependency "rails", ">= 6.1.0"
+  spec.add_dependency "turbo-rails"
+end


### PR DESCRIPTION
1) Decoupled logic related to the helper into a separate gem for more accurate and production-like testing
2) Added thread pool configuration - didn't have a chance to test
3) Added `on_loading`, `on_success`, and `on_failure` methods to define custom templates. (NOTE: Need to identify the root cause of why errors are not being tracked properly)
4) I didn’t have a chance to conduct thorough testing, so there may be issues

https://github.com/user-attachments/assets/9d95e422-94ff-44b4-a424-9a317b6eecc6

FYI: Most of the code, including README and yard comments, were generated using `Trae IDE` and `Claude-3.5-Sonnet`, so it may contain issues or bugs.