### PR TITLE
Blocks configuration reimplementation

### DIFF
--- a/app/controllers/async_controller.rb
+++ b/app/controllers/async_controller.rb
@@ -26,11 +26,4 @@ class AsyncController < ApplicationController
 
     render :index, locals: {id: params[:id], data1:, data2:, data3:, data4:}
   end
-
-  def widget
-    data = {hello: "world"}
-    # simulate long response
-    sleep 2
-    render partial: "traditional/widget", locals: {id: params[:id], data: data}
-  end
 end

--- a/app/controllers/async_with_block_controller.rb
+++ b/app/controllers/async_with_block_controller.rb
@@ -7,7 +7,7 @@ class AsyncWithBlockController < ApplicationController
     data1 = async_execute {
       sleep sleeptime1
       {data1: "world1", sleeptime: sleeptime1}
-     }
+    }
 
     sleeptime2 = 1
     data2 = async_execute {

--- a/app/controllers/async_with_block_controller.rb
+++ b/app/controllers/async_with_block_controller.rb
@@ -18,7 +18,6 @@ class AsyncWithBlockController < ApplicationController
     sleeptime3 = 3
     data3 = async_execute do
       sleep sleeptime3
-      # TODO: Need to figure oute why error is not tracked
       raise StandardError.new("Custom error message")
       {data3: "world3", sleeptime: sleeptime3}
     end

--- a/app/views/async/_widget.html.erb
+++ b/app/views/async/_widget.html.erb
@@ -1,3 +1,0 @@
-<%= turbo_frame_tag "widget-#{id}" do %>
-  <table border="1"><tr><td>Async Widget #<%= id %></td></tr></table>
-<% end %>

--- a/app/views/async_with_block/index.html.erb
+++ b/app/views/async_with_block/index.html.erb
@@ -19,9 +19,9 @@
         <div class="loading">
           <span>Loading Widget...</span>
         </div>
-      <% end.on_failure do |error| %>
+      <% end.on_failure do |errors| %>
         <div class="error">
-          Something went wrong: <%= error.to_s %>
+          Something went wrong: <%= errors.to_s %>
         </div>
       <% end %>
     </main>
@@ -35,9 +35,9 @@
         <div class="loading">
           <span>Loading Widget with custom error...</span>
         </div>
-      <% end.on_failure do |error| %>
+      <% end.on_failure do |errors| %>
         <div class="error">
-          Something went wrong: <%= error.to_s %>
+          Something went wrong: <%= errors.to_s %>
         </div>
       <% end %>
     </aside>

--- a/app/views/async_with_block/index.html.erb
+++ b/app/views/async_with_block/index.html.erb
@@ -10,43 +10,35 @@
     <main class="main-content">
       <p> Custom `loading`, `success` msgs </p>
 
-      <%= turbo_frame_tag_async "widget1", data1, data2 do |async_tag| %>
-        <% async_tag.on_loading do %>
-          <div class="loading">
-            <span>Loading Widget...</span>
-          </div>
-        <% end %>
-
-        <% async_tag.on_success do |d1, d2| %>
-          <div class="success">
-            Data 1: <%= d1 %>
-            Data 2: <%= d2 %>
-          </div>
-        <% end %>
-
-        <% async_tag.on_failure do |error| %>
-          <div class="error">
-            Something went wrong: <%= error.to_s %>
-          </div>
-        <% end %>
+      <%= turbo_frame_tag_async "widget1", data1, data2 do |d1, d2| %>
+        <div class="success">
+          Data 1: <%= d1 %>
+          Data 2: <%= d2 %>
+        </div>
+      <% end.on_loading do %>
+        <div class="loading">
+          <span>Loading Widget...</span>
+        </div>
+      <% end.on_failure do |error| %>
+        <div class="error">
+          Something went wrong: <%= error.to_s %>
+        </div>
       <% end %>
     </main>
 
     <aside class="right-sidebar">
       <p> Custom `loading`, `failure` msgs </p>
 
-      <%= turbo_frame_tag_async "widget3", data2, data3 do |async_tag| %>
-        <% async_tag.on_loading do %>
-          <div class="loading">
-            <span>Loading Widget with custom error...</span>
-          </div>
-        <% end %>
-
-        <% async_tag.on_failure do |error| %>
-          <div class="error">
-            Something went wrong: <%= error.class %>
-          </div>
-        <% end %>
+      <%= turbo_frame_tag_async "widget3", data2, data3 do |d2, d3| %>
+        You should not see this text. Block should fail!
+      <% end.on_loading do %>
+        <div class="loading">
+          <span>Loading Widget with custom error...</span>
+        </div>
+      <% end.on_failure do |error| %>
+        <div class="error">
+          Something went wrong: <%= error.to_s %>
+        </div>
       <% end %>
     </aside>
 

--- a/config/initializers/error_subscriber.rb
+++ b/config/initializers/error_subscriber.rb
@@ -1,0 +1,7 @@
+class ErrorSubscriber
+  def report(error, handled:, severity:, context:, source: nil)
+    Rails.logger.error([error.inspect, error.backtrace])
+  end
+end
+
+Rails.error.subscribe(ErrorSubscriber.new)

--- a/config/initializers/turbo_frame_async.rb
+++ b/config/initializers/turbo_frame_async.rb
@@ -1,0 +1,7 @@
+TurboFrameAsync.configure do |config|
+  config.default_executor_options = {
+    min_threads: 1,
+    max_threads: 10,
+    max_queue: 500
+  }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,6 @@ Rails.application.routes.draw do
   get "traditional/widget/:id", to: "traditional#widget", as: :traditional_widget
 
   get "async", to: "async#index"
-  get "async/widget/:id", to: "async#widget", as: :async_widget
 
   get "async_with_block", to: "async_with_block#index"
 end

--- a/turbo_frame_async/lib/turbo_frame_async.rb
+++ b/turbo_frame_async/lib/turbo_frame_async.rb
@@ -5,6 +5,7 @@ require "turbo-rails"
 require "turbo_frame_async/version"
 require "turbo_frame_async/configuration"
 require "turbo_frame_async/promise_handler"
+require "turbo_frame_async/rails_wrapping_executor"
 require "turbo_frame_async/helper"
 require "turbo_frame_async/railtie" if defined?(Rails)
 

--- a/turbo_frame_async/lib/turbo_frame_async/helper.rb
+++ b/turbo_frame_async/lib/turbo_frame_async/helper.rb
@@ -6,10 +6,6 @@ module TurboFrameAsync
   #
   # @since 0.1.0
   module Helper
-    # Size of the random hex string used for generating unique async tag IDs
-    # @api private
-    HEX_SIZE = 12
-
     # Creates an asynchronous Turbo Frame that handles multiple promises and their states.
     # This helper method sets up a Turbo Frame that can show different content based on
     # the promise states (loading, success, failure) and handles the async updates through
@@ -20,49 +16,18 @@ module TurboFrameAsync
     # @yield [handler] Block for defining state contents using the PromiseHandler
     # @yieldparam handler [PromiseHandler] The handler instance for setting up state blocks
     # @return [ActiveSupport::SafeBuffer] The HTML output containing the Turbo Frame
-    #
-    # @example Basic usage with all states
-    #   <%= turbo_frame_tag_async "user-profile", user_data_promise do |frame| %>
-    #     <% frame.on_loading do %>
-    #       <div class="spinner">Loading user data...</div>
-    #     <% end %>
-    #
-    #     <% frame.on_success do |user| %>
-    #       <div class="profile">
-    #         <h2><%= user.name %></h2>
-    #         <p><%= user.bio %></p>
-    #       </div>
-    #     <% end %>
-    #
-    #     <% frame.on_failure do |error| %>
-    #       <div class="error">
-    #         Failed to load user: <%= error.message %>
-    #       </div>
-    #     <% end %>
-    #   <% end %>
-    #
-    # @example Multiple promises
-    #   <%= turbo_frame_tag_async "dashboard", users_promise, posts_promise do |frame| %>
-    #     <% frame.on_success do |users, posts| %>
-    #       <div class="dashboard">
-    #         <div class="users"><%= render users %></div>
-    #         <div class="posts"><%= render posts %></div>
-    #       </div>
-    #     <% end %>
-    #   <% end %>
-    def turbo_frame_tag_async(dom_id, *promises)
-      async_tag_id = "async_tag_" + SecureRandom.hex(HEX_SIZE)
-      handler = PromiseHandler.new(dom_id, async_tag_id, self)
+    def turbo_frame_tag_async(dom_id, *promises, &block)
+      # TODO: Refactor PromiseHandler and give it better name
+      # maybe separate "logic"/promises handler and "tag rendering"
 
-      yield(handler) if block_given?
+      handler = PromiseHandler.new(dom_id, self)
 
-      output = ActiveSupport::SafeBuffer.new
-      output << turbo_stream_from(async_tag_id)
-      output << turbo_frame_tag(dom_id) { handler.render_loading }
+      # Default block should be considered as "success"
+      handler.on_success(block) if block_given?
 
       handler.handle_promises(promises)
 
-      output
+      handler
     end
 
     # Creates a promise that executes the given block on the configured executor

--- a/turbo_frame_async/lib/turbo_frame_async/promise_handler.rb
+++ b/turbo_frame_async/lib/turbo_frame_async/promise_handler.rb
@@ -12,17 +12,23 @@ module TurboFrameAsync
     include ActionView::Helpers::TagHelper
     include ActionView::Context
 
+    # Size of the random hex string used for generating unique async tag IDs
+    # @api private
+    HEX_SIZE = 6
+
     # Initializes a new PromiseHandler instance
     #
     # @param dom_id [String] The DOM ID of the target Turbo Frame element
-    # @param async_tag_id [String] The unique identifier for the async tag
     # @param view_context [ActionView::Base] The view context for rendering templates
     # @api private
-    def initialize(dom_id, async_tag_id, view_context = nil)
+    def initialize(dom_id, view_context = nil)
       @dom_id = dom_id
-      @async_tag_id = async_tag_id
       @view_context = view_context
       @blocks = default_blocks
+    end
+
+    def async_tag_id
+      @async_tag_id ||= "async_tag_#{SecureRandom.hex(HEX_SIZE)}"
     end
 
     # Sets the loading state content block
@@ -35,19 +41,7 @@ module TurboFrameAsync
     #   end
     def on_loading(&block)
       @blocks[:loading] = block if block_given?
-    end
-
-    # Sets the success state content block
-    #
-    # @yield [*values] Block that renders success state content
-    # @yieldparam values [Array] Values from the resolved promises
-    # @return [void]
-    # @example
-    #   handler.on_success do |user, posts|
-    #     render partial: "user_dashboard", locals: { user: user, posts: posts }
-    #   end
-    def on_success(&block)
-      @blocks[:success] = block if block_given?
+      self
     end
 
     # Sets the failure state content block
@@ -61,6 +55,12 @@ module TurboFrameAsync
     #   end
     def on_failure(&block)
       @blocks[:failure] = block if block_given?
+      self
+    end
+
+    def on_success(block)
+      @blocks[:success] = block
+      self
     end
 
     # Processes the given promises and handles their resolution/rejection
@@ -79,7 +79,7 @@ module TurboFrameAsync
           Rails.error.report(error)
           broadcast_failure(error)
         end
-    rescue StandardError => e
+    rescue => e
       Rails.error.report(e)
       broadcast_failure(e)
     end
@@ -92,6 +92,14 @@ module TurboFrameAsync
       render_block(@blocks[:loading])
     end
 
+    # This method is being called when instance of the handler is being rendered in template
+    def to_s
+      output = ActiveSupport::SafeBuffer.new
+      output << @view_context.turbo_stream_from(async_tag_id)
+      output << @view_context.turbo_frame_tag(@dom_id) { render_loading }
+      output
+    end
+
     private
 
     # Returns the default content blocks for each state
@@ -100,9 +108,9 @@ module TurboFrameAsync
     # @api private
     def default_blocks
       {
-        loading: -> { content_tag(:div, "Loading...") },
-        success: ->(*) { content_tag(:div, "Content loaded!") },
-        failure: ->(*) { content_tag(:div, "Error loading content") }
+        loading: -> { content_tag(:div, "Default block -> Loading...") },
+        success: ->(*) { content_tag(:div, "Default block -> Content loaded!") },
+        failure: ->(*) { content_tag(:div, "Default block -> Error loading content") }
       }
     end
 

--- a/turbo_frame_async/lib/turbo_frame_async/rails_wrapping_executor.rb
+++ b/turbo_frame_async/lib/turbo_frame_async/rails_wrapping_executor.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "concurrent-edge"
+
+#
+# A custom wrapper for Concurrent::WrappingExecutor that automatically wraps
+# tasks in the Rails executor context.
+#
+# This ensures that any task posted to the executor is executed within the
+# Rails context, preserving things like ActiveRecord connections and other
+# thread-local state that Rails manages.
+#
+module RailsWrappingExecutor
+  module_function
+
+  def new(executor)
+    Concurrent::WrappingExecutor.new(executor) do |*args, &task|
+      [*args, ->(*task_args) { Rails.application.executor.wrap { task.call(*task_args) } }]
+    end
+  end
+end


### PR DESCRIPTION
1) Added draft for block layout with default-success

```erb
      <%= turbo_frame_tag_async "widget1", data1, data2 do |d1, d2| %>
        <div class="success">
          Data 1: <%= d1 %>
          Data 2: <%= d2 %>
        </div>
      <% end.on_loading do %>
        <div class="loading">
          <span>Loading Widget...</span>
        </div>
      <% end.on_failure do |errors| %>
        <div class="error">
          Something went wrong: <%= errors.to_s %>
        </div>
      <% end %>
```


2) Added Rails Wrapping executor and updated `TurboFrameAsync.configure`

3) Added workaround for correct errors catching of non-resolved promised

NB! Also trying to remove excessive code comments that do not contain actual info now
I would suggest to avoid adding a lot of comments and example as lots and lots of things would be changing its shape yet